### PR TITLE
Enable auto-loading of configuration file when creating Settings instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ prefix: 'My Application'
 
 # Should we avoid outputting errors to the console? (ie in a GUI app)
 quiet: true | false
+
+# Should we automatically load the configuration file when the class is created?
+auto_load: true | false
 ```
 If these are not specified, Confoog will use the following defaults :
 
@@ -88,6 +91,7 @@ filename: '.confoog'
 create_file: false
 prefix: 'Configuration'
 quiet: false
+auto_load: false
 ```
 
 Confoog will set the following error constants which will be returned in the `.status['errors']` variable as needed :

--- a/lib/confoog.rb
+++ b/lib/confoog.rb
@@ -46,7 +46,8 @@ module Confoog
     quiet: false,
     prefix: 'Configuration',
     location: '~/',
-    filename: DEFAULT_CONFIG
+    filename: DEFAULT_CONFIG,
+    auto_load: false
   }
 
   # Provide an encapsulated class to access a YAML configuration file.
@@ -106,6 +107,9 @@ module Confoog
       status_set(errors: ERR_NO_ERROR)
       # make sure the file exists or can be created...
       check_exists(options)
+
+      # if auto_load is true, automatically load from file
+      load unless @options[:auto_load] == false
     end
 
     # Return the value of the 'quiet' option.

--- a/spec/configfile_yaml_spec.rb
+++ b/spec/configfile_yaml_spec.rb
@@ -8,11 +8,11 @@ describe Confoog::Settings, fakefs: true do
     # create an internal STDERR so we can still test this but it will not
     # clutter up the output
     $original_stderr = $stderr
-    $stderr = StringIO.new
+    #$stderr = StringIO.new
   end
 
   after(:all) do
-    $stderr = $original_stderr
+    #$stderr = $original_stderr
   end
 
   before(:each) do
@@ -79,6 +79,30 @@ describe Confoog::Settings, fakefs: true do
       expect($stderr).to receive(:puts).with(/empty/)
       s.load
       expect(s.status[:errors]).to eq Confoog::ERR_NOT_LOADING_EMPTY_FILE
+    end
+  end
+
+  context 'when created with auto_load: true' do
+    it 'should automatically load the specified configuration file' do
+      s = subject.new(location: '/home/tests', filename: 'reference.yaml', auto_load: true)
+      expect(s['location']).to eq '/home/tests'
+      expect(s['recurse']).to be true
+    end
+  end
+
+  context 'when created with auto_load: false' do
+    it 'should not load the specified configuration file' do
+      s = subject.new(location: '/home/tests', filename: 'reference.yaml', auto_load: false)
+      expect(s['location']).to be nil
+      expect(s['recurse']).to be nil
+    end
+  end
+
+  context 'when created without specifying an auto_load: value' do
+    it 'should not load the specified configuration file' do
+      s = subject.new(location: '/home/tests', filename: 'reference.yaml')
+      expect(s['location']).to be nil
+      expect(s['recurse']).to be nil
     end
   end
 end

--- a/spec/configfile_yaml_spec.rb
+++ b/spec/configfile_yaml_spec.rb
@@ -8,11 +8,11 @@ describe Confoog::Settings, fakefs: true do
     # create an internal STDERR so we can still test this but it will not
     # clutter up the output
     $original_stderr = $stderr
-    #$stderr = StringIO.new
+    $stderr = StringIO.new
   end
 
   after(:all) do
-    #$stderr = $original_stderr
+    $stderr = $original_stderr
   end
 
   before(:each) do


### PR DESCRIPTION
#### Added an `:auto_load` parameter to the initialize method.

When this is true the configuration file will be automatically loaded into memory when the instance is created.

Defaults to `false` if unspecified.