### PR TITLE
Implement an autosave functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ settings[50]
 settings[50][:two]
 # => "for the show"
 
+settings.quiet = true # squelch any error or status messages to console
+
+settings.autosave = false # disable autosave if it has been enabled with #new or #autosave
+
 settings.save # save all current parameters to the YAML file
 
 settings.load # load the settings from YAML file.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Or install it yourself as:
 ## Usage
 Currently Confoog will not allow 'nested' configuration types, however each variable can be an array or hash so multiple settings can be recorded for each variable and accessed (for a hash) by `settings[variable][hash_key]` or array using `settings[array].each`. In other words, treat the return from `settings[var]` as the type it contains. See examples below.
 
+By default, each time a configuration variable is created or changed the file on disk will be updated with this addition or change. If you intend to make a lot of consecutive changes or do not want the small performance hit of this, pass `auto_save: false` as a parameter to #new
+
 ```ruby
 require 'confoog'
 
@@ -82,8 +84,11 @@ quiet: true | false
 
 # Should we automatically load the configuration file when the class is created?
 auto_load: true | false
+
+# Should we automatically save the configuration file when a variable is created or changed?
+auto_save: true | false
 ```
-If these are not specified, Confoog will use the following defaults :
+If any of these are not specified, Confoog will use the following defaults :
 
 ```ruby
 location: '~/'
@@ -92,6 +97,7 @@ create_file: false
 prefix: 'Configuration'
 quiet: false
 auto_load: false
+auto_save: true
 ```
 
 Confoog will set the following error constants which will be returned in the `.status['errors']` variable as needed :

--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ Thoughts in no particular order.
 
 - Restrict configuration variables to a specified subset, or to only those that already exist in the YAML file.
 - A better way of dealing with multi-level variables - i.e. nested arrays, hashes etc.
-- option to save config file after any config variables are changed, not just explicitly with `Confoog::Settings.save`
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Or install it yourself as:
 ## Usage
 Currently Confoog will not allow 'nested' configuration types, however each variable can be an array or hash so multiple settings can be recorded for each variable and accessed (for a hash) by `settings[variable][hash_key]` or array using `settings[array].each`. In other words, treat the return from `settings[var]` as the type it contains. See examples below.
 
-By default, each time a configuration variable is created or changed the file on disk will be updated with this addition or change. If you intend to make a lot of consecutive changes or do not want the small performance hit of this, pass `auto_save: false` as a parameter to #new
+By default, each time a configuration variable is created or changed the file on disk will be updated with this addition or change. If you intend to make a lot of consecutive changes or do not want the small performance hit of this, pass `autosave: false` as a parameter to #new, or change set it false using the #autosave accessor.
 
 ```ruby
 require 'confoog'
@@ -87,10 +87,10 @@ prefix: 'My Application'
 quiet: true | false
 
 # Should we automatically load the configuration file when the class is created?
-auto_load: true | false
+autoload: true | false
 
 # Should we automatically save the configuration file when a variable is created or changed?
-auto_save: true | false
+autosave: true | false
 ```
 If any of these are not specified, Confoog will use the following defaults :
 
@@ -100,8 +100,8 @@ filename: '.confoog'
 create_file: false
 prefix: 'Configuration'
 quiet: false
-auto_load: false
-auto_save: true
+autoload: false
+autosave: true
 ```
 
 Confoog will set the following error constants which will be returned in the `.status['errors']` variable as needed :

--- a/Rakefile
+++ b/Rakefile
@@ -9,8 +9,7 @@ RuboCop::RakeTask.new do |task|
   task.options << 'lib'
 end
 Inch::Rake::Suggest.new do |suggest|
-  suggest.args << "--pedantic"
+  suggest.args << '--pedantic'
 end
-
 
 task default: [:rubocop, :inch, :spec]

--- a/lib/confoog.rb
+++ b/lib/confoog.rb
@@ -113,6 +113,26 @@ module Confoog
       load unless @options[:auto_load] == false
     end
 
+    # Return the value of the 'auto_save' option.
+    # @example
+    #   autosave_status = settings.autosave
+    #   => true
+    # @param [None]
+    # @return [Boolen] true if we are autosaving on change or addition.
+    def autosave
+      @options[:auto_save]
+    end
+
+    # Change the 'auto_save' option.
+    # @example
+    #   settings.autosave = false
+    #   => false
+    # @return [Boolean] The new value [true | false]
+    # @param autosave [Boolean] True to send messages to console for errors.
+    def autosave=(autosave)
+      @options[:auto_save] = autosave
+    end
+
     # Return the value of the 'quiet' option.
     # @example
     #   is_quiet = settings.quiet

--- a/lib/confoog.rb
+++ b/lib/confoog.rb
@@ -47,8 +47,8 @@ module Confoog
     prefix: 'Configuration',
     location: '~/',
     filename: DEFAULT_CONFIG,
-    auto_load: false,
-    auto_save: true
+    autoload: false,
+    autosave: true
   }
 
   # Provide an encapsulated class to access a YAML configuration file.
@@ -110,7 +110,7 @@ module Confoog
       check_exists(options)
 
       # if auto_load is true, automatically load from file
-      load unless @options[:auto_load] == false
+      load unless @options[:autoload] == false
     end
 
     # Return the value of the 'auto_save' option.
@@ -120,7 +120,7 @@ module Confoog
     # @param [None]
     # @return [Boolen] true if we are autosaving on change or addition.
     def autosave
-      @options[:auto_save]
+      @options[:autosave]
     end
 
     # Change the 'auto_save' option.
@@ -130,7 +130,7 @@ module Confoog
     # @return [Boolean] The new value [true | false]
     # @param autosave [Boolean] True to send messages to console for errors.
     def autosave=(autosave)
-      @options[:auto_save] = autosave
+      @options[:autosave] = autosave
     end
 
     # Return the value of the 'quiet' option.
@@ -219,7 +219,7 @@ module Confoog
     def []=(key, value)
       @config[key] = value
       # automatically save to file if this has been requested.
-      save unless @options[:auto_save] == false
+      save unless @options[:autosave] == false
     end
 
     # Returns the fully qualified path to the configuration file in use.

--- a/lib/confoog.rb
+++ b/lib/confoog.rb
@@ -1,4 +1,5 @@
 require 'confoog/version'
+require 'confoog/utility'
 require 'yaml'
 
 # rubocop:disable LineLength
@@ -83,6 +84,7 @@ module Confoog
   #   settings[50][:two]
   #   # => "for the show"
   class Settings
+    include ConfoogUtils
     attr_reader :filename, :location, :status
 
     # rubocop:enable LineLength
@@ -231,11 +233,6 @@ module Confoog
     end
 
     private
-
-    def console_output(message, severity)
-      return unless @options[:quiet] == false
-      $stderr.puts "#{@options[:prefix]} : #{severity} - #{message}"
-    end
 
     def save_to_yaml
       file = File.open(config_path, 'w')

--- a/lib/confoog.rb
+++ b/lib/confoog.rb
@@ -47,7 +47,8 @@ module Confoog
     prefix: 'Configuration',
     location: '~/',
     filename: DEFAULT_CONFIG,
-    auto_load: false
+    auto_load: false,
+    auto_save: true
   }
 
   # Provide an encapsulated class to access a YAML configuration file.
@@ -189,13 +190,16 @@ module Confoog
       @config[key]
     end
 
-    # Set a configuration key
+    # Set a configuration key.
+    # If auto_save: true then will also update the config file (default is true)
     # @example
     #   settings[:key] = "Value"
     #   settings[:array] = ["first", "second", "third"]
     # @return [<various>] Returns the variable that was assigned.
     def []=(key, value)
       @config[key] = value
+      # automatically save to file if this has been requested.
+      save unless @options[:auto_save] == false
     end
 
     # Returns the fully qualified path to the configuration file in use.

--- a/lib/confoog/utility.rb
+++ b/lib/confoog/utility.rb
@@ -1,0 +1,10 @@
+# A collection of utility functions for the Confoog class
+module ConfoogUtils
+  private
+
+  # Display output to the console with the severity noted, unless we are quiet.
+  def console_output(message, severity)
+    return unless @options[:quiet] == false
+    $stderr.puts "#{@options[:prefix]} : #{severity} - #{message}"
+  end
+end

--- a/spec/configfile_yaml_spec.rb
+++ b/spec/configfile_yaml_spec.rb
@@ -38,6 +38,10 @@ describe Confoog::Settings, fakefs: true do
       expect(s.status[:errors]).to eq Confoog::ERR_NOT_WRITING_EMPTY_FILE
     end
 
+    it 'should not write to disk if auto_save: is not specified' do
+      pending 'to write test'
+    end
+
     it 'should save an easy config to valid YAML' do
       s = subject.new(location: '/home/tests', create_file: true)
       s['location'] = '/home/tests'
@@ -55,6 +59,20 @@ describe Confoog::Settings, fakefs: true do
       expect($stderr).to receive(:puts).with(/Cannot/)
       s.save
       expect(s.status[:errors]).to eq Confoog::ERR_CANT_SAVE_CONFIGURATION
+    end
+
+    context 'when auto_save: true' do
+      it 'should automatically save when a new variable is added' do
+        pending 'to write test'
+      end
+
+      it 'should automatically save when a variable is changed' do
+        pending 'to write test'
+      end
+
+      it 'however should do none of this if auto_save: false' do
+        pending 'to write test'
+      end
     end
   end
 

--- a/spec/configfile_yaml_spec.rb
+++ b/spec/configfile_yaml_spec.rb
@@ -38,8 +38,10 @@ describe Confoog::Settings, fakefs: true do
       expect(s.status[:errors]).to eq Confoog::ERR_NOT_WRITING_EMPTY_FILE
     end
 
-    it 'should not write to disk if auto_save: is not specified' do
-      pending 'to write test'
+    it 'should by default save to disk if auto_save: is not specified' do
+      s = subject.new(location: '/home/tests', create_file: true)
+      s['location'] = '/home/tests'
+      expect(File.read('/home/tests/.confoog')).to include '/home/tests'
     end
 
     it 'should save an easy config to valid YAML' do
@@ -63,15 +65,23 @@ describe Confoog::Settings, fakefs: true do
 
     context 'when auto_save: true' do
       it 'should automatically save when a new variable is added' do
-        pending 'to write test'
+        s = subject.new(location: '/home/tests', create_file: true, auto_save: true)
+        s['location'] = '/home/tests'
+        expect(File.read('/home/tests/.confoog')).to include '/home/tests'
       end
 
       it 'should automatically save when a variable is changed' do
-        pending 'to write test'
+        s = subject.new(location: '/home/tests', create_file: true, auto_save: true)
+        s['location'] = '/home/tests'
+        s['location'] = '/usr/my/directory'
+        expect(File.read('/home/tests/.confoog')).not_to include '/home/tests'
+        expect(File.read('/home/tests/.confoog')).to include '/usr/my/directory'
       end
 
       it 'however should do none of this if auto_save: false' do
-        pending 'to write test'
+        s = subject.new(location: '/home/tests', create_file: true, auto_save: false)
+        s['location'] = '/home/tests'
+        expect(File.read('/home/tests/.confoog')).not_to include '/home/tests'
       end
     end
   end

--- a/spec/configfile_yaml_spec.rb
+++ b/spec/configfile_yaml_spec.rb
@@ -7,12 +7,12 @@ describe Confoog::Settings, fakefs: true do
   before(:all) do
     # create an internal STDERR so we can still test this but it will not
     # clutter up the output
-    $original_stderr = $stderr
-    $stderr = StringIO.new
+    # $original_stderr = $stderr
+    # $stderr = StringIO.new
   end
 
   after(:all) do
-    $stderr = $original_stderr
+    # $stderr = $original_stderr
   end
 
   before(:each) do
@@ -65,13 +65,13 @@ describe Confoog::Settings, fakefs: true do
 
     context 'when auto_save: true' do
       it 'should automatically save when a new variable is added' do
-        s = subject.new(location: '/home/tests', create_file: true, auto_save: true)
+        s = subject.new(location: '/home/tests', create_file: true, autosave: true)
         s['location'] = '/home/tests'
         expect(File.read('/home/tests/.confoog')).to include '/home/tests'
       end
 
       it 'should automatically save when a variable is changed' do
-        s = subject.new(location: '/home/tests', create_file: true, auto_save: true)
+        s = subject.new(location: '/home/tests', create_file: true, autosave: true)
         s['location'] = '/home/tests'
         s['location'] = '/usr/my/directory'
         expect(File.read('/home/tests/.confoog')).not_to include '/home/tests'
@@ -79,7 +79,7 @@ describe Confoog::Settings, fakefs: true do
       end
 
       it 'however should do none of this if auto_save: false' do
-        s = subject.new(location: '/home/tests', create_file: true, auto_save: false)
+        s = subject.new(location: '/home/tests', create_file: true, autosave: false)
         s['location'] = '/home/tests'
         expect(File.read('/home/tests/.confoog')).not_to include '/home/tests'
       end
@@ -87,7 +87,7 @@ describe Confoog::Settings, fakefs: true do
 
     context 'using the #autosave method before changing or adding variables' do
       it 'should correctly set and read the #autosave status' do
-        s = subject.new(location: '/home/tests', create_file: true, auto_save: true)
+        s = subject.new(location: '/home/tests', create_file: true, autosave: true)
         s.autosave = false
         expect(s.autosave).to be false
         s.autosave = true
@@ -95,21 +95,19 @@ describe Confoog::Settings, fakefs: true do
       end
 
       it 'should not save if #autosave is set false' do
-        s = subject.new(location: '/home/tests', create_file: true, auto_save: true)
+        s = subject.new(location: '/home/tests', create_file: true, autosave: true)
         s.autosave = false
         s['location'] = '/home/tests'
         expect(File.read('/home/tests/.confoog')).not_to include '/home/tests'
       end
 
       it 'should save if #autosave is true' do
-        s = subject.new(location: '/home/tests', create_file: true, auto_save: false)
+        s = subject.new(location: '/home/tests', create_file: true, autosave: false)
         s.autosave = true
         s['location'] = '/home/tests'
         expect(File.read('/home/tests/.confoog')).to include '/home/tests'
       end
-
     end
-
   end
 
   context 'when loading config file' do
@@ -138,7 +136,7 @@ describe Confoog::Settings, fakefs: true do
 
   context 'when created with auto_load: true' do
     it 'should automatically load the specified configuration file' do
-      s = subject.new(location: '/home/tests', filename: 'reference.yaml', auto_load: true)
+      s = subject.new(location: '/home/tests', filename: 'reference.yaml', autoload: true)
       expect(s['location']).to eq '/home/tests'
       expect(s['recurse']).to be true
     end
@@ -146,7 +144,7 @@ describe Confoog::Settings, fakefs: true do
 
   context 'when created with auto_load: false' do
     it 'should not load the specified configuration file' do
-      s = subject.new(location: '/home/tests', filename: 'reference.yaml', auto_load: false)
+      s = subject.new(location: '/home/tests', filename: 'reference.yaml', autoload: false)
       expect(s['location']).to be nil
       expect(s['recurse']).to be nil
     end

--- a/spec/configfile_yaml_spec.rb
+++ b/spec/configfile_yaml_spec.rb
@@ -84,6 +84,32 @@ describe Confoog::Settings, fakefs: true do
         expect(File.read('/home/tests/.confoog')).not_to include '/home/tests'
       end
     end
+
+    context 'using the #autosave method before changing or adding variables' do
+      it 'should correctly set and read the #autosave status' do
+        s = subject.new(location: '/home/tests', create_file: true, auto_save: true)
+        s.autosave = false
+        expect(s.autosave).to be false
+        s.autosave = true
+        expect(s.autosave).to be true
+      end
+
+      it 'should not save if #autosave is set false' do
+        s = subject.new(location: '/home/tests', create_file: true, auto_save: true)
+        s.autosave = false
+        s['location'] = '/home/tests'
+        expect(File.read('/home/tests/.confoog')).not_to include '/home/tests'
+      end
+
+      it 'should save if #autosave is true' do
+        s = subject.new(location: '/home/tests', create_file: true, auto_save: false)
+        s.autosave = true
+        s['location'] = '/home/tests'
+        expect(File.read('/home/tests/.confoog')).to include '/home/tests'
+      end
+
+    end
+
   end
 
   context 'when loading config file' do

--- a/spec/confoog_spec.rb
+++ b/spec/confoog_spec.rb
@@ -70,7 +70,7 @@ describe Confoog do
         settings.location = 'this will fail'
         expect(settings.quiet).to be false
       end
-      it 'should return the full filename and path in .config_path' do
+      it 'should return the full filename and path in #config_path' do
         settings = subject.new(location: '/home/tests', filename: '.i_do_exist')
         expect(settings.config_path).to eq '/home/tests/.i_do_exist'
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,11 +12,6 @@ require 'pp' # work around https://github.com/defunkt/fakefs/issues/99
 require 'confoog'
 require 'fakefs/spec_helpers'
 
-def show_file(filename)
-  contents = File.open(filename, 'r') { |file| file.read }
-  puts contents
-end
-
 RSpec.configure do |config|
   config.include FakeFS::SpecHelpers, fakefs: true
 end


### PR DESCRIPTION
By default the class wil now automatically save any new or changed variables to the configuration file.
This can be disabled by either :

1. Pass `autosave: false` to `#new` when creating
2. Set the value of `#autosave` to `false` in your code - this can be changed on the fly at any time.

Also a slight refactoring to keep the class < 100 lines (created a naughty utility function). True refactoring by probably moving the status and console output functionality into a separate class will come soon.