### PR TITLE
General refactoring and removal of a few 'code smells'

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,11 @@ Confoog will set the following error constants which will be returned in the `.s
 ```ruby
 ERR_NO_ERROR = 0 # no error condition, command was succesfull
 ERR_FILE_NOT_EXIST = 1 # specified configuration file does not exist
-ERR_CANT_CHANGE = 2 # directory and file can only be specified through `.new()`
-ERR_CANT_CREATE_FILE = 4 # cannot create the requested configuration file
-ERR_NOT_WRITING_EMPTY_FILE = 8 # not attempting to save an empty configuration
-ERR_CANT_SAVE_CONFIGURATION = 16 # Failed to save the configuration file
-ERR_NOT_LOADING_EMPTY_FILE = 32 # not atempting to load an empty config file
-ERR_CANT_LOAD = 64 # Cannot load configuration data from file.
+ERR_CANT_CREATE_FILE = 2 # cannot create the requested configuration file
+ERR_NOT_WRITING_EMPTY_FILE = 4 # not attempting to save an empty configuration
+ERR_CANT_SAVE_CONFIGURATION = 8 # Failed to save the configuration file
+ERR_NOT_LOADING_EMPTY_FILE = 16 # not atempting to load an empty config file
+ERR_CANT_LOAD = 32 # Cannot load configuration data from file.
 
 INFO_FILE_CREATED = 256 # Information - specified file was created
 INFO_FILE_LOADED = 512 # Information - Config file was loaded successfully
@@ -129,6 +128,7 @@ Thoughts in no particular order.
 
 - Restrict configuration variables to a specified subset, or to only those that already exist in the YAML file.
 - A better way of dealing with multi-level variables - i.e. nested arrays, hashes etc.
+- Write standalone tests for the 'Status' class - right now it is tested at 100% by the application tests though would probably be good to have dedicated tests too
 
 ## Development
 

--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,7 @@ RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new do |task|
   task.options << 'lib'
 end
+
 Inch::Rake::Suggest.new do |suggest|
   suggest.args << '--pedantic'
 end

--- a/lib/confoog.rb
+++ b/lib/confoog.rb
@@ -22,10 +22,6 @@ module Confoog
   }
 
   # Provide an encapsulated class to access a YAML configuration file.
-  # @!attribute [r] filename
-  #   @return [String] The configuration filename in use.
-  # @!attribute [r] location
-  #   @return [String] The directory storing the configuration file.
   # @!attribute [r] status
   #   @return [Hash] A hash containing status variables.
   # @example
@@ -53,7 +49,7 @@ module Confoog
   #   settings[50][:two]
   #   # => "for the show"
   class Settings
-    attr_reader :filename, :location, :status
+    attr_reader :status
 
     # rubocop:enable LineLength
 
@@ -69,13 +65,12 @@ module Confoog
 
       # Hash containing any error or return from methods
       @status = Status.new(@options[:quiet], @options[:prefix])
-      @location = @options[:location]
-      @filename = @options[:filename]
-
-      @config = {}
-
       # clear the error condition as default.
       @status.clear_error
+
+      # Initialize the Configuration to and empty hash.
+      @config = {}
+
       # make sure the file exists or can be created...
       check_exists(options)
 
@@ -149,20 +144,6 @@ module Confoog
       @status.set(errors: Status::ERR_CANT_LOAD)
     end
 
-    # dummy method currently to stop changing location by caller once created,
-    # @return [hash] an error flag in the ':status' variable.
-    # @param [Optional] Parameter is ignored
-    def location=(*)
-      @status.set(errors: Status::ERR_CANT_CHANGE)
-    end
-
-    # dummy method currently to stop changing filename by caller once created,
-    # @return [hash] an error flag in the ':status' variable.
-    # @param optional Parameter is ignored
-    def filename=(*)
-      @status.set(errors: Status::ERR_CANT_CHANGE)
-    end
-
     # Read the configuration key (key)
     # @example
     #   key = settings[:key]
@@ -188,7 +169,7 @@ module Confoog
     #   path = config_path
     # @return [String] Full path and filename of the configuration file.
     def config_path
-      File.expand_path(File.join(@location, @filename))
+      File.expand_path(File.join(@options[:location], @options[:filename]))
     end
 
     private
@@ -198,9 +179,7 @@ module Confoog
         @status.set(config_exists: false, errors: Status::ERR_FILE_NOT_EXIST)
         return
       end
-      file = File.open(config_path, 'w')
-      file.write(@config.to_yaml)
-      file.close
+      File.open(config_path, 'w') { |file| file.write(@config.to_yaml) }
     rescue
       @status.set(errors: Status::ERR_CANT_SAVE_CONFIGURATION)
     end

--- a/lib/confoog/status.rb
+++ b/lib/confoog/status.rb
@@ -1,27 +1,19 @@
 # Provide error messages and console output when required.
 class Status
-  # @!attribute prefix
-  #   @return [String] String to pre-pend on any error put to console
-  attr_accessor :prefix
-  # @!attribute quiet
-  #   @return [Boolean] Do we output anything to console or not
-  attr_accessor :quiet
   # No error condition exists
   ERR_NO_ERROR = 0
   # The specified file does not exist
   ERR_FILE_NOT_EXIST = 1
-  # You cannot change location or filename after class is instantiated
-  ERR_CANT_CHANGE = 2
   # Was unable to create the specified file
-  ERR_CANT_CREATE_FILE = 4
+  ERR_CANT_CREATE_FILE = 2
   # There are no configuration variables set, so not writing empty file
-  ERR_NOT_WRITING_EMPTY_FILE = 8
+  ERR_NOT_WRITING_EMPTY_FILE = 4
   # Cannot save to the specified file for some reason
-  ERR_CANT_SAVE_CONFIGURATION = 16
+  ERR_CANT_SAVE_CONFIGURATION = 8
   # The specified file is empty so not trying to load settings from it
-  ERR_NOT_LOADING_EMPTY_FILE = 32
+  ERR_NOT_LOADING_EMPTY_FILE = 16
   # Cannot load the specified file for some reason.
-  ERR_CANT_LOAD = 64
+  ERR_CANT_LOAD = 32
 
   # Information - file was created successfully
   INFO_FILE_CREATED = 256
@@ -39,13 +31,19 @@ class Status
   # not have a message, there will be no output.
   ERROR_STRINGS = {
     ERR_FILE_NOT_EXIST => 'The specified Configuration file does not exist.',
-    ERR_CANT_CHANGE => 'Cannot change filename after creation',
     ERR_CANT_CREATE_FILE => 'Cannot create the specified Configuration file!',
     ERR_NOT_WRITING_EMPTY_FILE => 'Not saving empty configuration data!',
     ERR_CANT_SAVE_CONFIGURATION => 'Cannot save configuration data!',
     ERR_NOT_LOADING_EMPTY_FILE => 'The configuration file is empty!',
     ERR_CANT_LOAD => 'Cannot load configuration Data!'
   }
+
+  # @!attribute prefix
+  #   @return [String] String to pre-pend on any error put to console
+  attr_accessor :prefix
+  # @!attribute quiet
+  #   @return [Boolean] Do we output anything to console or not
+  attr_accessor :quiet
 
   # Class initializer.
   # @example
@@ -94,15 +92,17 @@ class Status
   # @param status [Hash] one or more hash-pairs of status information.
   # @return Unspecified
   def set(status)
-    status.each do |key, value|
-      @status[key] = value
-    end
-    return if ERROR_STRINGS[@status[:errors]].nil?
-    severity = (@status[:errors] <= 64) ? 'Error' : 'Info'
-    console_output(ERROR_STRINGS[@status[:errors]], severity)
+    status.each { |key, value| @status[key] = value }
+    return unless error_string
+    console_output(error_string, (@status[:errors] < 256) ? 'Error' : 'Info')
   end
 
   private
+
+  # return the error string corresponding to the current error number
+  def error_string
+    ERROR_STRINGS[@status[:errors]]
+  end
 
   # Display output to the console with the severity noted, unless we are quiet.
   # @param [String] message

--- a/spec/configfile_yaml_spec.rb
+++ b/spec/configfile_yaml_spec.rb
@@ -7,12 +7,12 @@ describe Confoog::Settings, fakefs: true do
   before(:all) do
     # create an internal STDERR so we can still test this but it will not
     # clutter up the output
-    # $original_stderr = $stderr
-    # $stderr = StringIO.new
+    @original_stderr = $stderr
+    $stderr = StringIO.new
   end
 
   after(:all) do
-    # $stderr = $original_stderr
+    $stderr = @original_stderr
   end
 
   before(:each) do


### PR DESCRIPTION
Notably :
 * Refactor `Status.set` & `Settings.save_to_yaml`
 * Refactor - remove the `:location` and `:filename` accessors
   - These are not really needed and were requiring extra code to prevent them being changed. Cuts down on total number of instance variables too.
 * Move error_string out to a method, cuts down on repetition.
 * Tests - remove a global variable used to squelch console output. Changed to an instance variable instead. Cleans up a code smell.
 * README - Add another TODO
 * Standardize Rakefile line spacing

All RSpec tests, Rubocop and Inch are at 100%. This PR also drops 'reek' report down to 2 smells from 8, and closes the last 2 noted by `pullrequest.com`