### PR TITLE
Fix test fail on Ruby 1.9.3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
-require 'reek/rake/task'
+
 require 'inch/rake'
 
 RSpec::Core::RakeTask.new(:spec)
@@ -14,10 +14,18 @@ Inch::Rake::Suggest.new do |suggest|
   suggest.args << '--pedantic'
 end
 
-Reek::Rake::Task.new do |t|
-  t.fail_on_error = false
-  t.verbose       = true
-  t.reek_opts     = '-U'
+# reek is not comp[atible with Ruby < 2.0]
+if RUBY_VERSION > '2.0'
+  require 'reek/rake/task'
+  Reek::Rake::Task.new do |t|
+    t.fail_on_error = false
+    t.verbose       = true
+    t.reek_opts     = '-U'
+  end
+else
+  task :reek do
+    # Empty task
+  end
 end
 
 task default: [:rubocop, :inch, :reek, :spec]

--- a/confoog.gemspec
+++ b/confoog.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+  spec.extensions    = ['ext/reek_or_no_reek.rb']
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'
@@ -31,5 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'inch'
   spec.add_development_dependency 'simplecov', '~> 0.10'
   spec.add_development_dependency 'pullreview-coverage'
-  spec.add_development_dependency 'reek', '~> 3.3'
+
+  # Depend on Ruby version
+  spec.add_development_dependency 'reek', '~> 3.3' if RUBY_VERSION > '2.0'
 end


### PR DESCRIPTION
'rake' would fail on Ruby 1.9.3 since the 'reek' gem needs Ruby >2.0.
Add conditional dependancy in gemspec and Rakefile to bypass this.

Signed-off-by: Seapagan <seapagan@gmail.com>